### PR TITLE
Fixed browser crash on player death. Game now restarts with fresh map.

### DIFF
--- a/lib/core/game.js
+++ b/lib/core/game.js
@@ -15,6 +15,11 @@ Roguelike.Game = function(userSettings) {
 	this.isInitialized = false;
 
 	/**
+	 * @property {Boolean} isActive - Boolean to see if the game is currently active
+	 */
+	this.isActive = false;
+
+	/**
 	 * @property {Roguelike.Map} map - Reference to the current map
 	 */
 	this.map = null;
@@ -92,25 +97,11 @@ Roguelike.Game.prototype = {
 		//Create a new keyboard
 		this.keyboard = new Roguelike.Keyboard();
 
-		//Initialize the map
-		this.map = new Roguelike.Map(this);
-
-		//Create the map factory
-		this.mapFactory = new Roguelike.MapFactory(this);
-
-		//Create the map factory
-		this.mapDecorator = new Roguelike.MapDecorator(this);
-
-		//Add a new entity group to the map
-		this.map.entities = new Roguelike.Group(this);
-
 		//Create a new scheduler
 		this.scheduler = new Roguelike.Scheduler();
 
-		//Generate rooms for this map
-		this.mapFactory.generateRooms();
-
-		this.mapDecorator.decorateMap();
+		//Initialize the map
+		this.initializeMap();
 
 		//Create the camera object
 		this.camera = new Roguelike.Camera(this, {x: 0, y: 0});
@@ -128,20 +119,8 @@ Roguelike.Game.prototype = {
 		//Create the player entity
 		this.player = Roguelike.PlayerFactory.newPlayerWarrior(this, playerPosition, playerControls);
 
-		//Add the player to the entities list of the current map
-		this.map.entities.addEntity(this.player);
-
-		//Get the tile that the player is going to spawn on
-		var startingTile = this.map.tiles[playerPosition.x][playerPosition.y];
-
-		//Add the player to the tile it spawns on
-		startingTile.addEntity(this.player);
-
-		//Add the player to the scheduler
-		this.scheduler.add(this.player, true);
-
-		//Let the camera follow the player entity
-		this.camera.follow(this.player, this.settings.canvas.width / 2, this.settings.canvas.height / 2);
+		//Initialize the player
+		this.initializePlayer();
 
 		//Initialize the movement system
 		this.staticSystems.movementSystem = new Roguelike.Systems.Movement(this);
@@ -165,6 +144,68 @@ Roguelike.Game.prototype = {
 		//The game is fully initialized!
 		this.isInitialized = true;
 
+		//Make the game active for the first time
+		this.isActive = true;
+
+	},
+
+	/**
+	 * Creates and populates a new map
+	 * @protected
+	 */
+	initializeMap: function() {
+
+		//Initialize the map
+		this.map = new Roguelike.Map(this);
+
+		//Create the map factory
+		this.mapFactory = new Roguelike.MapFactory(this);
+
+		//Create the map decorator
+		this.mapDecorator = new Roguelike.MapDecorator(this);
+
+		//Add a new entity group to the map
+		this.map.entities = new Roguelike.Group(this);
+
+		//Generate rooms for this map
+		this.mapFactory.generateRooms();
+
+		this.mapDecorator.decorateMap();
+
+	},
+
+	/**
+	 * Initializes and adds the player to the game
+	 * @protected
+	 */
+	initializePlayer: function() {
+
+		//Get the start position of the player from the map
+		var startPosition = new Roguelike.Vector2(this.map.entrance.x, this.map.entrance.y);
+
+		//Set the player's start position
+		var playerPosition = this.player.getComponent("position");
+		playerPosition.position = startPosition;
+
+		//Restore the player's health
+		var playerHealth = this.player.getComponent("health");
+		playerHealth.health = playerHealth.maxHealth;
+
+		//Add the player to the entities list of the current map
+		this.map.entities.addEntity(this.player);
+
+		//Get the tile that the player is going to spawn on
+		var startingTile = this.map.tiles[startPosition.x][startPosition.y];
+
+		//Add the player to the tile it spawns on
+		startingTile.addEntity(this.player);
+
+		//Add the player to the scheduler
+		this.scheduler.add(this.player, true);
+
+		//Let the camera follow the player entity
+		this.camera.follow(this.player, this.settings.canvas.width / 2, this.settings.canvas.height / 2);
+
 	},
 
 	/**
@@ -173,6 +214,13 @@ Roguelike.Game.prototype = {
 	 * @protected
 	 */
 	update: function() {
+
+		//If the game is not currently active, restart
+		if (this.isInitialized && !this.isActive) {
+
+			this.restart();
+
+		}
 
 		//Request a new animation frame and call the update function again
 		requestAnimationFrame(this.update.bind(this));
@@ -193,6 +241,28 @@ Roguelike.Game.prototype = {
 
 		}
 
+
+	},
+
+	/**
+	 * Restarts the game with a fresh map and player
+	 * @protected
+	 */
+	restart: function() {
+
+		//Clear events from the scheduler
+		this.scheduler.clear();
+
+		//Initialize map and player
+		this.initializeMap();
+		this.initializePlayer();
+
+		//Initialize the pathfinding system with the new game map
+		this.staticSystems.pathfindingSystem.game = this;
+		this.staticSystems.pathfindingSystem.initialize();
+
+		//Make game active
+		this.isActive = true;
 
 	}
 

--- a/lib/gameobjects/systems/combat.js
+++ b/lib/gameobjects/systems/combat.js
@@ -58,9 +58,14 @@ Roguelike.Systems.Combat.prototype = {
 	 */
 	removeEntity: function(entity) {
 
+		//Check for the player entity being removed
 		if(entity.hasComponent("keyboardControl")) {
-			// Lock the scheduler to stop the game if the player is removed
+
+			//Lock the scheduler to stop the game
 			this.game.scheduler.lock();
+			//Make the game inactive
+			this.game.isActive = false;
+
 		}
 
 		//Remove the entity from the map's list

--- a/lib/gameobjects/systems/combat.js
+++ b/lib/gameobjects/systems/combat.js
@@ -58,11 +58,9 @@ Roguelike.Systems.Combat.prototype = {
 	 */
 	removeEntity: function(entity) {
 
-		//TODO: Don't make the player invincible
 		if(entity.hasComponent("keyboardControl")) {
-
-			return;
-
+			// Lock the scheduler to stop the game if the player is removed
+			this.game.scheduler.lock();
 		}
 
 		//Remove the entity from the map's list


### PR DESCRIPTION
The issue where a JS process would lock up the browser seemed to be a result of the scheduler no longer being locked between enemy pathfinding events, which was a result of the player entity being removed. You'd end up with an enemy stuck in a loop of finding a path to the player, [somewhere in here](https://github.com/ruscoe/dungeongeneration/blob/master/lib/gameobjects/systems/pathfinding.js#L54).

I modified the combat code to lock the scheduler and set the game to an inactive state when the player is removed [here](https://github.com/ruscoe/dungeongeneration/blob/master/lib/gameobjects/systems/combat.js#L62).

I set up the game so it will automatically restart with a fresh map when it [finds itself in an inactive state](https://github.com/ruscoe/dungeongeneration/blob/master/lib/core/game.js#L221).

Seems to all be working from the testing I did. Let me know what you think.
