### PR TITLE
LightMap is now cleared when game becomes inactive. Related to issue #5

### DIFF
--- a/lib/gameobjects/systems/lightmap.js
+++ b/lib/gameobjects/systems/lightmap.js
@@ -33,6 +33,11 @@ Roguelike.Systems.LightMap = function(game) {
 		[1, 0, 0, 1, -1, 0, 0, -1]
 	];
 
+	/**
+	 * @property {Boolean} tilesLit - Boolean to see if game tiles have been lit
+	 */
+	this.tilesLit = false;
+
 };
 
 Roguelike.Systems.LightMap.prototype = {
@@ -43,14 +48,25 @@ Roguelike.Systems.LightMap.prototype = {
 	 */
 	update: function() {
 
-		//Then loop through all keyboardControl Entities and check the user input, and handle accordingly
-		var entities = this.game.map.entities.getEntities("lightSource", "position");
+		if (this.game.isActive) {
 
-		//Loop through all matching entities
-		for(var i = 0; i < entities.length; i++) {
+			//Then loop through all keyboardControl Entities and check the user input, and handle accordingly
+			var entities = this.game.map.entities.getEntities("lightSource", "position");
 
-			//Perform the needed operations for this specific system on one entity
-			this.handleSingleEntity(entities[i]);
+			//Loop through all matching entities
+			for(var i = 0; i < entities.length; i++) {
+
+				//Perform the needed operations for this specific system on one entity
+				this.handleSingleEntity(entities[i]);
+
+			}
+
+			this.tilesLit = true;
+
+		}else if(this.tilesLit) {
+
+			this.clear();
+			this.tilesLit = false;
 
 		}
 


### PR DESCRIPTION
[This little bug](https://github.com/stefanweck/dungeongeneration/issues/5) was related to the LightMap not being cleared between maps.

Now the LightMap only updates when the game is active. Also added a boolean (tilesLit) to prevent the clear function being called repeatedly if the game is ever inactive for a while (in case of a "game over" screen, menu, etc, in the future.)
