### PR TITLE
Entities can now be limited to attacking specific entity types

### DIFF
--- a/lib/factories/decorationfactory.js
+++ b/lib/factories/decorationfactory.js
@@ -26,7 +26,7 @@ var DecorationFactory = {
 	newGrass: function(game, position) {
 
 		//Create the entity
-		var entity = new Entity(game, "Grass");
+		var entity = new Entity(game, "Decoration", "Grass");
 
 		//The starting position of the entity
 		entity.addComponent(new Position(position));

--- a/lib/factories/enemyfactory.js
+++ b/lib/factories/enemyfactory.js
@@ -59,7 +59,9 @@ var EnemyFactory = {
 		entity.addComponent(new Weapon(4));
 
 		//This entity is capable of fighting
-		entity.addComponent(new CanFight(game));
+		var canAttackTypes = ["Player"];
+
+		entity.addComponent(new CanFight(game, canAttackTypes));
 
 		//Add a tooltip to this entity
 		entity.addComponent(new Tooltip(
@@ -112,7 +114,9 @@ var EnemyFactory = {
 		entity.addComponent(new Weapon(10));
 
 		//This entity is capable of fighting
-		entity.addComponent(new CanFight(game));
+		var canAttackTypes = ["Player"];
+
+		entity.addComponent(new CanFight(game, canAttackTypes));
 
 		//Add a tooltip to this entity
 		entity.addComponent(new Tooltip(

--- a/lib/factories/enemyfactory.js
+++ b/lib/factories/enemyfactory.js
@@ -33,7 +33,7 @@ var EnemyFactory = {
 	newSpider: function(game, position) {
 
 		//Create the entity
-		var entity = new Entity(game, "Quick Spider", 2000);
+		var entity = new Entity(game, "Arachnid", "Quick Spider", 2000);
 
 		//Give the entity a health of 100 points
 		entity.addComponent(new Health(20));
@@ -86,7 +86,7 @@ var EnemyFactory = {
 	newSkeleton: function(game, position) {
 
 		//Create the entity
-		var entity = new Entity(game, "Skeleton", 1000);
+		var entity = new Entity(game, "Undead", "Skeleton", 1000);
 
 		//Give the entity a health of 100 points
 		entity.addComponent(new Health(50));

--- a/lib/factories/playerfactory.js
+++ b/lib/factories/playerfactory.js
@@ -66,7 +66,9 @@ var PlayerFactory = {
 		entity.addComponent(new Weapon(7));
 
 		//This entity is capable of fighting
-		entity.addComponent(new CanFight(game));
+		var canAttackTypes = [];
+
+		entity.addComponent(new CanFight(game, canAttackTypes));
 
 		//Add a tooltip to this entity
 		entity.addComponent(new Tooltip(

--- a/lib/factories/playerfactory.js
+++ b/lib/factories/playerfactory.js
@@ -34,7 +34,7 @@ var PlayerFactory = {
 	newPlayerWarrior: function(game, position, controls) {
 
 		//Create the entity
-		var entity = new Entity(game, "You", 1000);
+		var entity = new Entity(game, "Player", "You", 1000);
 
 		//Give the player a health of 100 points
 		entity.addComponent(new Health(100));

--- a/lib/factories/propfactory.js
+++ b/lib/factories/propfactory.js
@@ -28,7 +28,7 @@ var PropFactory = {
 	newEntrance: function(game, position) {
 
 		//Create the entity
-		var entity = new Entity(game, "Entrance");
+		var entity = new Entity(game, "Prop", "Entrance");
 
 		//The starting position of the entity
 		entity.addComponent(new Position(position));
@@ -53,7 +53,7 @@ var PropFactory = {
 	newExit: function(game, position) {
 
 		//Create the entity
-		var entity = new Entity(game, "Exit");
+		var entity = new Entity(game, "Prop", "Exit");
 
 		//The starting position of the entity
 		entity.addComponent(new Position(position));
@@ -78,7 +78,7 @@ var PropFactory = {
 	newDoor: function(game, position) {
 
 		//Create the entity
-		var entity = new Entity(game, "Wooden Door");
+		var entity = new Entity(game, "Prop", "Wooden Door");
 
 		//The starting position of the entity
 		entity.addComponent(new Position(position));

--- a/lib/gameobjects/components/canfight.js
+++ b/lib/gameobjects/components/canfight.js
@@ -11,8 +11,9 @@ var Event = require('../../input/event.js');
  * @classdesc An component that tells the system that this entity can fight!
  *
  * @property {Game} game - Reference to the current game object
+ * @property {Array} canAttackTypes - Array of entity types that can be attacked
  */
-var CanFight = function(game) {
+var CanFight = function(game, canAttackTypes) {
 
 	/**
 	 * @property {String} name - The name of this system. This field is always required!
@@ -23,6 +24,11 @@ var CanFight = function(game) {
 	 * @property {Game} game - Reference to the current game object
 	 */
 	this.game = game;
+
+	/**
+	 * @property {Array} canAttackTypes - Array of entity types that can be attacked
+	 */
+	this.canAttackTypes = canAttackTypes;
 
 	/**
 	 * @property {Event} events - Event holder
@@ -54,9 +60,35 @@ CanFight.prototype = {
 	 */
 	bumpInto: function(entity, collisionEntity) {
 
-		//The combat system will handle the combat!
-		this.game.staticSystems.combatSystem.handleSingleEntity(entity, collisionEntity);
+		//Determine if the colliding entity can attack this entity
+		var collisionEntityCanFight = collisionEntity.getComponent("canFight");
 
+		if (collisionEntityCanFight && collisionEntityCanFight.canAttackEntity(entity)) {
+
+			//The combat system will handle the combat!
+			this.game.staticSystems.combatSystem.handleSingleEntity(entity, collisionEntity);
+
+		}
+
+	},
+
+	/**
+	 * Function to determine if an entity can be attacked by this entity
+	 * @protected
+	 */
+	canAttackEntity: function(entity) {
+
+		//An empty array of attack types means any entity type may be attacked
+		if (this.canAttackTypes.length === 0) {
+			return true;
+		}
+
+		//Otherwise check for the entity type
+		if (this.canAttackTypes.indexOf(entity.type) >= 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 };

--- a/lib/gameobjects/entity.js
+++ b/lib/gameobjects/entity.js
@@ -8,15 +8,21 @@
  * @classdesc A single entity in the game world
  *
  * @param {Game} game - Reference to the currently running game
+ * @param {String} type - The type of this entity
  * @param {String} name - The name of this entity
  * @param {Number} speed - The speed of this entity
  */
-var Entity = function(game, name, speed) {
+var Entity = function(game, type, name, speed) {
 
 	/**
 	 * @property {Game} game - Reference to the current game object
 	 */
 	this.game = game;
+
+	/**
+	 * @property {String} type - The type of this entity
+	 */
+	this.type = type;
 
 	/**
 	 * @property {String} name - The name of this entity


### PR DESCRIPTION
- Added a type property to entities
- Allowed entities to be limited to attacking only certain entity types, so enemies don't always attack each other.

I didn't commit the recompiled JS file from /dist so you would be less likely to run into merge conflicts. I can commit that file in the future if it makes things easier.

I've modified combat to take entity type into account here: https://github.com/stefanweck/dungeongeneration/pull/9/files#diff-b5fb76dd7831ab523605ab86d0304b21R61

Let me know what you think. I'm open to changes, as always.
